### PR TITLE
Use a different default `ranking_fn` for `NSPGE`

### DIFF
--- a/autogoal/search/_nspge.py
+++ b/autogoal/search/_nspge.py
@@ -1,8 +1,79 @@
 import math
+from typing import Optional
+from autogoal.utils import Min, Gb, Sec
 from ._pge import PESearch
 
 
 class NSPESearch(PESearch):
+    def __init__(
+        self,
+        # =============================
+        # args for SearchAlgorithm
+        # =============================
+        generator_fn=None,
+        fitness_fn=None,
+        pop_size=None,
+        maximize=True,
+        errors="raise",
+        early_stop=0.5,
+        evaluation_timeout: int = 10 * Sec,
+        memory_limit: int = 4 * Gb,
+        search_timeout: int = 5 * Min,
+        target_fn=None,
+        allow_duplicates=True,
+        number_of_solutions=None,
+        ranking_fn=None,
+        # =============================
+        # args for PESearch
+        # =============================
+        learning_factor: float = 0.05,
+        selection: float = 0.2,
+        epsilon_greed: float = 0.1,
+        random_state: Optional[int] = None,
+        name: str = None,
+        save: bool = False,
+        # =============================
+        # others
+        # =============================
+        **kwargs
+    ):
+        def default_ranking_fn(_, fns):
+            # use worst possible ranking by default, although all rankings should be
+            # set to a number by the end of the function
+            rankings = [-math.inf] * len(fns)
+            fronts = self.non_dominated_sort(fns)
+            for ranking, front in enumerate(fronts):
+                for index in front:
+                    # the closest you are to front 0 the highest your ranking
+                    rankings[index] = -ranking
+            return rankings
+
+        if ranking_fn is None:
+            ranking_fn = default_ranking_fn
+
+        super().__init__(
+            generator_fn=generator_fn,
+            fitness_fn=fitness_fn,
+            pop_size=pop_size,
+            maximize=maximize,
+            errors=errors,
+            early_stop=early_stop,
+            evaluation_timeout=evaluation_timeout,
+            memory_limit=memory_limit,
+            search_timeout=search_timeout,
+            target_fn=target_fn,
+            allow_duplicates=allow_duplicates,
+            number_of_solutions=number_of_solutions,
+            ranking_fn=ranking_fn,
+            learning_factor=learning_factor,
+            selection=selection,
+            epsilon_greed=epsilon_greed,
+            random_state=random_state,
+            name=name,
+            save=save,
+            **kwargs
+        )
+
     def _indices_of_fittest(self, fns):
         fronts = self.non_dominated_sort(fns)
         indices, k = [], int(self._selection * len(fns))

--- a/autogoal/search/_nspge.py
+++ b/autogoal/search/_nspge.py
@@ -22,6 +22,7 @@ class NSPESearch(PESearch):
         target_fn=None,
         allow_duplicates=True,
         number_of_solutions=None,
+        filter_fn=None,
         ranking_fn=None,
         # =============================
         # args for PESearch
@@ -51,6 +52,9 @@ class NSPESearch(PESearch):
         if ranking_fn is None:
             ranking_fn = default_ranking_fn
 
+        if number_of_solutions is None and filter_fn is None:
+            filter_fn = lambda ranking, solution, fitness: ranking == 0
+
         super().__init__(
             generator_fn=generator_fn,
             fitness_fn=fitness_fn,
@@ -64,6 +68,7 @@ class NSPESearch(PESearch):
             target_fn=target_fn,
             allow_duplicates=allow_duplicates,
             number_of_solutions=number_of_solutions,
+            filter_fn=filter_fn,
             ranking_fn=ranking_fn,
             learning_factor=learning_factor,
             selection=selection,


### PR DESCRIPTION
When using `NSPGE` as the search algorithm, the default `ranking_fn` will be set to a function that assigns a ranking based on the front that each solution is assigned to during _**non-dominated sort**_.